### PR TITLE
Zig 0.15 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,31 +5,14 @@ on:
   pull_request:
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.1
-
-  codespell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@master
-        with:
-          check_filenames: true
-          skip: ./.git,./vendor,*_test.go,go.sum,go.mod
-
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
-      - run: |
-          make build
+          version: 0.15.2
+      - run: zig build
 
   fmt:
     runs-on: ubuntu-latest
@@ -37,35 +20,34 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
-      - run: |
-          make fmt
+          version: 0.15.2
+      - run: zig build fmt
 
-  unit_test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
-      - run: |
-          sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev git
-          git clone https://github.com/SimonKagstrom/kcov.git
-          cd kcov
-          git checkout v43
-          mkdir build
-          cd build
-          cmake ..
-          make
-          sudo make install
-      - run: |
-          make test
-          make coverage
+          version: 0.15.2
+      - run: zig build test
 
-      - name: Upload coverage reports to Codecov
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+      - name: Install kcov
+        run: |
+          sudo apt-get install -y binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev cmake
+          git clone https://github.com/SimonKagstrom/kcov.git
+          cd kcov && git checkout v43 && mkdir build && cd build && cmake .. && make && sudo make install
+      - run: zig build cov
+      - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
           file: .coverage/test/cov.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/build.zig
+++ b/build.zig
@@ -9,21 +9,18 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // add library
-    const lib = b.addStaticLibrary(.{
-        .name = "ocispec",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
-        .root_source_file = b.path("src/distribution/lib.zig"),
-        .target = target,
-        .optimize = optimize,
-        .single_threaded = false,
-    });
-
-    b.installArtifact(lib);
-
     const oci_spec_module = b.addModule("ocispec", .{
         .root_source_file = b.path("src/lib.zig"),
+    });
+
+    // Library object for documentation generation
+    const lib = b.addObject(.{
+        .name = "ocispec",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     // step generate docs
@@ -46,9 +43,11 @@ pub fn build(b: *std.Build) void {
     }) |example_name| {
         const example = b.addExecutable(.{
             .name = example_name,
-            .root_source_file = b.path(b.fmt("examples/{s}.zig", .{example_name})),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(b.fmt("examples/{s}.zig", .{example_name})),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
 
         example.root_module.addImport("ocispec", oci_spec_module);
@@ -56,26 +55,25 @@ pub fn build(b: *std.Build) void {
     }
 
     // step run tests
-    const lib_unit_tests = b.addTest(.{
-        // Assuming this needs to be the same root file as the library,
-        // since it's the library we're building tests for?
+    const test_module = b.createModule(.{
         .root_source_file = b.path("tests/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
-    lib_unit_tests.root_module.addImport("ocispec", oci_spec_module);
+    test_module.addImport("ocispec", oci_spec_module);
+    const lib_unit_tests = b.addTest(.{
+        .root_module = test_module,
+    });
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
 
-    // step generate code cov
+    // step generate code coverage
     const cov_step = b.step("cov", "Generate code coverage");
-
     const cov_run = b.addSystemCommand(&.{ "kcov", "--clean", "--include-pattern=src/", ".coverage/" });
     cov_run.addArtifactArg(lib_unit_tests);
-
     cov_step.dependOn(&cov_run.step);
 
     // step check formatting

--- a/examples/artifact_manifest.zig
+++ b/examples/artifact_manifest.zig
@@ -13,11 +13,9 @@ pub fn main() !void {
 
     const config_content = try artifact_manifest.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{config_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{config_content});
-
-    try bw.flush();
 }

--- a/examples/image_config.zig
+++ b/examples/image_config.zig
@@ -12,11 +12,9 @@ pub fn main() !void {
     const image_config = try image.Configuration.initFromFile(allocator, file_path);
     const config_content = try image_config.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{config_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{config_content});
-
-    try bw.flush();
 }

--- a/examples/image_index.zig
+++ b/examples/image_index.zig
@@ -20,11 +20,11 @@ pub fn main() !void {
         .digest = try image.Digest.initFromString(allocator, "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"),
     };
 
-    var manifests = std.ArrayList(image.Descriptor).init(allocator);
+    var manifests: std.ArrayListUnmanaged(image.Descriptor) = .{};
 
-    try manifests.append(index_manifest);
+    try manifests.append(allocator, index_manifest);
 
-    const image_manifests: []image.Descriptor = try manifests.toOwnedSlice();
+    const image_manifests: []image.Descriptor = try manifests.toOwnedSlice(allocator);
 
     const image_index = image.Index{
         .mediaType = image.MediaType.ImageIndex,
@@ -33,11 +33,9 @@ pub fn main() !void {
 
     const image_index_content = try image_index.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{image_index_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{image_index_content});
-
-    try bw.flush();
 }

--- a/examples/image_manifest.zig
+++ b/examples/image_manifest.zig
@@ -12,8 +12,8 @@ pub fn main() !void {
     const media_config = image.MediaType.ImageConfig;
     const media_layer = image.MediaType.ImageLayerGzip;
 
-    var mlayers = std.ArrayList(image.Descriptor).init(allocator);
-    try mlayers.append(image.Descriptor{
+    var mlayers: std.ArrayListUnmanaged(image.Descriptor) = .{};
+    try mlayers.append(allocator, image.Descriptor{
         .mediaType = media_layer,
         .digest = try image.Digest.initFromString(
             allocator,
@@ -22,7 +22,7 @@ pub fn main() !void {
         .size = 32654,
     });
 
-    const manifest_layers: []image.Descriptor = try mlayers.toOwnedSlice();
+    const manifest_layers: []image.Descriptor = try mlayers.toOwnedSlice(allocator);
 
     const manifest = image.Manifest{
         .mediaType = media_manifest,
@@ -39,11 +39,9 @@ pub fn main() !void {
 
     const manifest_content = try manifest.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{manifest_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{manifest_content});
-
-    try bw.flush();
 }

--- a/examples/image_oci_layout.zig
+++ b/examples/image_oci_layout.zig
@@ -12,11 +12,9 @@ pub fn main() !void {
 
     const oci_layout_content = try oci_layout.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{oci_layout_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{oci_layout_content});
-
-    try bw.flush();
 }

--- a/examples/runtime_config.zig
+++ b/examples/runtime_config.zig
@@ -13,11 +13,9 @@ pub fn main() !void {
 
     const config_content = try spec.toStringPretty(allocator);
 
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var write_buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&write_buf);
+    try stdout.interface.print("{s}\n", .{config_content});
+    stdout.interface.flush() catch {};
 
-    try stdout.print("{s}\n", .{config_content});
-
-    try bw.flush();
 }

--- a/src/runtime/define.zig
+++ b/src/runtime/define.zig
@@ -75,119 +75,119 @@ pub const ExecCPUAffinity = struct {
 };
 
 pub fn getDefaultRootlessMounts(allocator: Allocator) ![]Mount {
-    var mounts = std.ArrayList(Mount).init(allocator);
+    var mounts: std.ArrayListUnmanaged(Mount) = .{};
 
-    var pts_opts = std.ArrayList([]const u8).init(allocator);
-    try pts_opts.append("nosuid");
-    try pts_opts.append("noexec");
-    try pts_opts.append("newinstance");
-    try pts_opts.append("ptmxmode=0666");
-    try pts_opts.append("mode=0620");
-    try mounts.append(Mount{
+    var pts_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try pts_opts.append(allocator, "nosuid");
+    try pts_opts.append(allocator, "noexec");
+    try pts_opts.append(allocator, "newinstance");
+    try pts_opts.append(allocator, "ptmxmode=0666");
+    try pts_opts.append(allocator, "mode=0620");
+    try mounts.append(allocator, Mount{
         .destination = "/dev/pts",
         .type = "devpts",
         .source = "devpts",
-        .options = try pts_opts.toOwnedSlice(),
+        .options = try pts_opts.toOwnedSlice(allocator),
     });
 
-    var sys_opts = std.ArrayList([]const u8).init(allocator);
-    try sys_opts.append("nosuid");
-    try sys_opts.append("noexec");
-    try sys_opts.append("nodev");
-    try sys_opts.append("ro");
-    try sys_opts.append("rbind");
-    try mounts.append(Mount{
+    var sys_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try sys_opts.append(allocator, "nosuid");
+    try sys_opts.append(allocator, "noexec");
+    try sys_opts.append(allocator, "nodev");
+    try sys_opts.append(allocator, "ro");
+    try sys_opts.append(allocator, "rbind");
+    try mounts.append(allocator, Mount{
         .destination = "/sys",
         .type = "sysfs",
         .source = "sysfs",
-        .options = try sys_opts.toOwnedSlice(),
+        .options = try sys_opts.toOwnedSlice(allocator),
     });
 
-    return mounts.toOwnedSlice();
+    return mounts.toOwnedSlice(allocator);
 }
 
 pub fn getDefaultMounts(allocator: Allocator) ![]Mount {
-    var mounts = std.ArrayList(Mount).init(allocator);
-    try mounts.append(Mount{
+    var mounts: std.ArrayListUnmanaged(Mount) = .{};
+    try mounts.append(allocator, Mount{
         .destination = "/proc",
         .type = "proc",
         .source = "proc",
     });
 
-    var dev_opts = std.ArrayList([]const u8).init(allocator);
-    try dev_opts.append("nosuid");
-    try dev_opts.append("strictatime");
-    try dev_opts.append("mode=755");
-    try dev_opts.append("size=65536k");
-    try mounts.append(Mount{
+    var dev_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try dev_opts.append(allocator, "nosuid");
+    try dev_opts.append(allocator, "strictatime");
+    try dev_opts.append(allocator, "mode=755");
+    try dev_opts.append(allocator, "size=65536k");
+    try mounts.append(allocator, Mount{
         .destination = "/dev",
         .type = "tmpfs",
         .source = "tmpfs",
-        .options = try dev_opts.toOwnedSlice(),
+        .options = try dev_opts.toOwnedSlice(allocator),
     });
 
-    var pts_opts = std.ArrayList([]const u8).init(allocator);
-    try pts_opts.append("nosuid");
-    try pts_opts.append("noexec");
-    try pts_opts.append("newinstance");
-    try pts_opts.append("ptmxmode=0666");
-    try pts_opts.append("mode=0620");
-    try pts_opts.append("gid=5");
-    try mounts.append(Mount{
+    var pts_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try pts_opts.append(allocator, "nosuid");
+    try pts_opts.append(allocator, "noexec");
+    try pts_opts.append(allocator, "newinstance");
+    try pts_opts.append(allocator, "ptmxmode=0666");
+    try pts_opts.append(allocator, "mode=0620");
+    try pts_opts.append(allocator, "gid=5");
+    try mounts.append(allocator, Mount{
         .destination = "/dev/pts",
         .type = "devpts",
         .source = "devpts",
-        .options = try pts_opts.toOwnedSlice(),
+        .options = try pts_opts.toOwnedSlice(allocator),
     });
 
-    var shm_opts = std.ArrayList([]const u8).init(allocator);
-    try shm_opts.append("nosuid");
-    try shm_opts.append("noexec");
-    try shm_opts.append("nodev");
-    try shm_opts.append("mode=1777");
-    try shm_opts.append("size=65536k");
-    try mounts.append(Mount{
+    var shm_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try shm_opts.append(allocator, "nosuid");
+    try shm_opts.append(allocator, "noexec");
+    try shm_opts.append(allocator, "nodev");
+    try shm_opts.append(allocator, "mode=1777");
+    try shm_opts.append(allocator, "size=65536k");
+    try mounts.append(allocator, Mount{
         .destination = "/dev/shm",
         .type = "tmpfs",
         .source = "shm",
-        .options = try shm_opts.toOwnedSlice(),
+        .options = try shm_opts.toOwnedSlice(allocator),
     });
 
-    var mqueue_opts = std.ArrayList([]const u8).init(allocator);
-    try mqueue_opts.append("nosuid");
-    try mqueue_opts.append("noexec");
-    try mqueue_opts.append("nodev");
-    try mounts.append(Mount{
+    var mqueue_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try mqueue_opts.append(allocator, "nosuid");
+    try mqueue_opts.append(allocator, "noexec");
+    try mqueue_opts.append(allocator, "nodev");
+    try mounts.append(allocator, Mount{
         .destination = "/dev/mqueue",
         .type = "mqueue",
         .source = "mqueue",
-        .options = try mqueue_opts.toOwnedSlice(),
+        .options = try mqueue_opts.toOwnedSlice(allocator),
     });
 
-    var sys_opts = std.ArrayList([]const u8).init(allocator);
-    try sys_opts.append("nosuid");
-    try sys_opts.append("noexec");
-    try sys_opts.append("nodev");
-    try sys_opts.append("ro");
-    try mounts.append(Mount{
+    var sys_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try sys_opts.append(allocator, "nosuid");
+    try sys_opts.append(allocator, "noexec");
+    try sys_opts.append(allocator, "nodev");
+    try sys_opts.append(allocator, "ro");
+    try mounts.append(allocator, Mount{
         .destination = "/sys",
         .type = "sysfs",
         .source = "sysfs",
-        .options = try sys_opts.toOwnedSlice(),
+        .options = try sys_opts.toOwnedSlice(allocator),
     });
 
-    var cgroup_opts = std.ArrayList([]const u8).init(allocator);
-    try cgroup_opts.append("nosuid");
-    try cgroup_opts.append("noexec");
-    try cgroup_opts.append("nodev");
-    try cgroup_opts.append("relatime");
-    try cgroup_opts.append("ro");
-    try mounts.append(Mount{
+    var cgroup_opts: std.ArrayListUnmanaged([]const u8) = .{};
+    try cgroup_opts.append(allocator, "nosuid");
+    try cgroup_opts.append(allocator, "noexec");
+    try cgroup_opts.append(allocator, "nodev");
+    try cgroup_opts.append(allocator, "relatime");
+    try cgroup_opts.append(allocator, "ro");
+    try mounts.append(allocator, Mount{
         .destination = "/sys/fs/cgroup",
         .type = "cgroup",
         .source = "cgroup",
-        .options = try cgroup_opts.toOwnedSlice(),
+        .options = try cgroup_opts.toOwnedSlice(allocator),
     });
 
-    return mounts.toOwnedSlice();
+    return mounts.toOwnedSlice(allocator);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -31,18 +31,10 @@ pub fn writeFileContent(allocator: Allocator, file_path: []const u8, content: []
 }
 
 pub fn toJsonString(allocator: Allocator, value: anytype, pretty: bool) ![]const u8 {
-    const jsonValue = switch (pretty) {
-        true => try std.json.stringifyAlloc(
-            allocator,
-            value,
-            .{ .emit_strings_as_arrays = false, .emit_null_optional_fields = false, .whitespace = .indent_4 },
-        ),
-        false => try std.json.stringifyAlloc(
-            allocator,
-            value,
-            .{ .emit_strings_as_arrays = false, .emit_null_optional_fields = false },
-        ),
-    };
+    const options: std.json.Stringify.Options = if (pretty)
+        .{ .emit_strings_as_arrays = false, .emit_null_optional_fields = false, .whitespace = .indent_4 }
+    else
+        .{ .emit_strings_as_arrays = false, .emit_null_optional_fields = false };
 
-    return jsonValue;
+    return std.json.Stringify.valueAlloc(allocator, value, options);
 }

--- a/tests/image/define_arch.zig
+++ b/tests/image/define_arch.zig
@@ -5,154 +5,154 @@ const testing = std.testing;
 
 test "image define Arch jsonStringify" {
     // I386
-    var archI386Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archI386Buf.deinit();
+    var archI386Buf: std.ArrayList(u8) = .{};
+    defer archI386Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.I386, archI386Buf.writer());
+    try arch.jsonStringify(&arch.I386, archI386Buf.writer(testing.allocator));
 
     // Amd64
-    var archAmd64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archAmd64Buf.deinit();
+    var archAmd64Buf: std.ArrayList(u8) = .{};
+    defer archAmd64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Amd64, archAmd64Buf.writer());
+    try arch.jsonStringify(&arch.Amd64, archAmd64Buf.writer(testing.allocator));
 
     // Amd64p32
-    var archAmd64p32Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archAmd64p32Buf.deinit();
+    var archAmd64p32Buf: std.ArrayList(u8) = .{};
+    defer archAmd64p32Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Amd64p32, archAmd64p32Buf.writer());
+    try arch.jsonStringify(&arch.Amd64p32, archAmd64p32Buf.writer(testing.allocator));
 
     // ARM
-    var archARMBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archARMBuf.deinit();
+    var archARMBuf: std.ArrayList(u8) = .{};
+    defer archARMBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.ARM, archARMBuf.writer());
+    try arch.jsonStringify(&arch.ARM, archARMBuf.writer(testing.allocator));
 
     // ARMbe
-    var archARMbeBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archARMbeBuf.deinit();
+    var archARMbeBuf: std.ArrayList(u8) = .{};
+    defer archARMbeBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.ARMbe, archARMbeBuf.writer());
+    try arch.jsonStringify(&arch.ARMbe, archARMbeBuf.writer(testing.allocator));
 
     // ARM64
-    var archARM64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archARM64Buf.deinit();
+    var archARM64Buf: std.ArrayList(u8) = .{};
+    defer archARM64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.ARM64, archARM64Buf.writer());
+    try arch.jsonStringify(&arch.ARM64, archARM64Buf.writer(testing.allocator));
 
     // ARM64be
-    var archARM64beBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archARM64beBuf.deinit();
+    var archARM64beBuf: std.ArrayList(u8) = .{};
+    defer archARM64beBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.ARM64be, archARM64beBuf.writer());
+    try arch.jsonStringify(&arch.ARM64be, archARM64beBuf.writer(testing.allocator));
 
     // LoongArch64
-    var archLoongArch64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archLoongArch64Buf.deinit();
+    var archLoongArch64Buf: std.ArrayList(u8) = .{};
+    defer archLoongArch64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.LoongArch64, archLoongArch64Buf.writer());
+    try arch.jsonStringify(&arch.LoongArch64, archLoongArch64Buf.writer(testing.allocator));
 
     // Mips
-    var archMipsBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archMipsBuf.deinit();
+    var archMipsBuf: std.ArrayList(u8) = .{};
+    defer archMipsBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mips, archMipsBuf.writer());
+    try arch.jsonStringify(&arch.Mips, archMipsBuf.writer(testing.allocator));
 
     // Mipsle
-    var archMipsleBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archMipsleBuf.deinit();
+    var archMipsleBuf: std.ArrayList(u8) = .{};
+    defer archMipsleBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mipsle, archMipsleBuf.writer());
+    try arch.jsonStringify(&arch.Mipsle, archMipsleBuf.writer(testing.allocator));
 
     // Mips64
-    var archMips64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archMips64Buf.deinit();
+    var archMips64Buf: std.ArrayList(u8) = .{};
+    defer archMips64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mips64, archMips64Buf.writer());
+    try arch.jsonStringify(&arch.Mips64, archMips64Buf.writer(testing.allocator));
 
     // Mips64le
-    var archMips64leBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archMips64leBuf.deinit();
+    var archMips64leBuf: std.ArrayList(u8) = .{};
+    defer archMips64leBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mips64le, archMips64leBuf.writer());
+    try arch.jsonStringify(&arch.Mips64le, archMips64leBuf.writer(testing.allocator));
 
     // Mips64p32
-    var archMips64p32Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archMips64p32Buf.deinit();
+    var archMips64p32Buf: std.ArrayList(u8) = .{};
+    defer archMips64p32Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mips64p32, archMips64p32Buf.writer());
+    try arch.jsonStringify(&arch.Mips64p32, archMips64p32Buf.writer(testing.allocator));
 
     // Mips64p32le
-    var archMips64p32leBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archMips64p32leBuf.deinit();
+    var archMips64p32leBuf: std.ArrayList(u8) = .{};
+    defer archMips64p32leBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Mips64p32le, archMips64p32leBuf.writer());
+    try arch.jsonStringify(&arch.Mips64p32le, archMips64p32leBuf.writer(testing.allocator));
 
     // PowerPC
-    var archPowerPCBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archPowerPCBuf.deinit();
+    var archPowerPCBuf: std.ArrayList(u8) = .{};
+    defer archPowerPCBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.PowerPC, archPowerPCBuf.writer());
+    try arch.jsonStringify(&arch.PowerPC, archPowerPCBuf.writer(testing.allocator));
 
     // PowerPC64
-    var archPowerPC64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archPowerPC64Buf.deinit();
+    var archPowerPC64Buf: std.ArrayList(u8) = .{};
+    defer archPowerPC64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.PowerPC64, archPowerPC64Buf.writer());
+    try arch.jsonStringify(&arch.PowerPC64, archPowerPC64Buf.writer(testing.allocator));
 
     // PowerPC64le
-    var archPowerPC64leBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archPowerPC64leBuf.deinit();
+    var archPowerPC64leBuf: std.ArrayList(u8) = .{};
+    defer archPowerPC64leBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.PowerPC64le, archPowerPC64leBuf.writer());
+    try arch.jsonStringify(&arch.PowerPC64le, archPowerPC64leBuf.writer(testing.allocator));
 
     // RISCV
-    var archRISCVBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archRISCVBuf.deinit();
+    var archRISCVBuf: std.ArrayList(u8) = .{};
+    defer archRISCVBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.RISCV, archRISCVBuf.writer());
+    try arch.jsonStringify(&arch.RISCV, archRISCVBuf.writer(testing.allocator));
 
     // RISCV64
-    var archRISCV64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archRISCV64Buf.deinit();
+    var archRISCV64Buf: std.ArrayList(u8) = .{};
+    defer archRISCV64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.RISCV64, archRISCV64Buf.writer());
+    try arch.jsonStringify(&arch.RISCV64, archRISCV64Buf.writer(testing.allocator));
 
     // S390
-    var archS390Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archS390Buf.deinit();
+    var archS390Buf: std.ArrayList(u8) = .{};
+    defer archS390Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.S390, archS390Buf.writer());
+    try arch.jsonStringify(&arch.S390, archS390Buf.writer(testing.allocator));
 
     // S390x
-    var archS390xBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archS390xBuf.deinit();
+    var archS390xBuf: std.ArrayList(u8) = .{};
+    defer archS390xBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.S390x, archS390xBuf.writer());
+    try arch.jsonStringify(&arch.S390x, archS390xBuf.writer(testing.allocator));
 
     // SPARC
-    var archSPARCBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archSPARCBuf.deinit();
+    var archSPARCBuf: std.ArrayList(u8) = .{};
+    defer archSPARCBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.SPARC, archSPARCBuf.writer());
+    try arch.jsonStringify(&arch.SPARC, archSPARCBuf.writer(testing.allocator));
 
     // SPARC64
-    var archSPARC64Buf = std.ArrayList(u8).init(testing.allocator);
-    defer archSPARC64Buf.deinit();
+    var archSPARC64Buf: std.ArrayList(u8) = .{};
+    defer archSPARC64Buf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.SPARC64, archSPARC64Buf.writer());
+    try arch.jsonStringify(&arch.SPARC64, archSPARC64Buf.writer(testing.allocator));
 
     // Wasm
-    var archWasmBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archWasmBuf.deinit();
+    var archWasmBuf: std.ArrayList(u8) = .{};
+    defer archWasmBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Wasm, archWasmBuf.writer());
+    try arch.jsonStringify(&arch.Wasm, archWasmBuf.writer(testing.allocator));
 
     // Other
-    var archOtherBuf = std.ArrayList(u8).init(testing.allocator);
-    defer archOtherBuf.deinit();
+    var archOtherBuf: std.ArrayList(u8) = .{};
+    defer archOtherBuf.deinit(testing.allocator);
 
-    try arch.jsonStringify(&arch.Other, archOtherBuf.writer());
+    try arch.jsonStringify(&arch.Other, archOtherBuf.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(archI386Buf.items, "\"386\"");

--- a/tests/image/define_media_type.zig
+++ b/tests/image/define_media_type.zig
@@ -219,88 +219,88 @@ test "image define OS jsonParse" {
 
 test "image define MediaType jsonStringify" {
     // Descriptor
-    var bufDesc = std.ArrayList(u8).init(testing.allocator);
-    defer bufDesc.deinit();
+    var bufDesc: std.ArrayList(u8) = .{};
+    defer bufDesc.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.Descriptor, bufDesc.writer());
+    try imgtype.jsonStringify(&imgtype.Descriptor, bufDesc.writer(testing.allocator));
 
     // LayoutHeader
-    var bufLayoutHeader = std.ArrayList(u8).init(testing.allocator);
-    defer bufLayoutHeader.deinit();
+    var bufLayoutHeader: std.ArrayList(u8) = .{};
+    defer bufLayoutHeader.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.LayoutHeader, bufLayoutHeader.writer());
+    try imgtype.jsonStringify(&imgtype.LayoutHeader, bufLayoutHeader.writer(testing.allocator));
 
     // ImageManifest
-    var bugImgManifest = std.ArrayList(u8).init(testing.allocator);
-    defer bugImgManifest.deinit();
+    var bugImgManifest: std.ArrayList(u8) = .{};
+    defer bugImgManifest.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageManifest, bugImgManifest.writer());
+    try imgtype.jsonStringify(&imgtype.ImageManifest, bugImgManifest.writer(testing.allocator));
 
     // ImageIndex
-    var bufImgIndex = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgIndex.deinit();
+    var bufImgIndex: std.ArrayList(u8) = .{};
+    defer bufImgIndex.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageIndex, bufImgIndex.writer());
+    try imgtype.jsonStringify(&imgtype.ImageIndex, bufImgIndex.writer(testing.allocator));
 
     // ImageLayer
-    var bufImgLayer = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgLayer.deinit();
+    var bufImgLayer: std.ArrayList(u8) = .{};
+    defer bufImgLayer.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayer, bufImgLayer.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayer, bufImgLayer.writer(testing.allocator));
 
     // ImageLayerGzip
-    var bugImgLayerGzip = std.ArrayList(u8).init(testing.allocator);
-    defer bugImgLayerGzip.deinit();
+    var bugImgLayerGzip: std.ArrayList(u8) = .{};
+    defer bugImgLayerGzip.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayerGzip, bugImgLayerGzip.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayerGzip, bugImgLayerGzip.writer(testing.allocator));
 
     // ImageLayerZstd
-    var bufImgLayerZstd = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgLayerZstd.deinit();
+    var bufImgLayerZstd: std.ArrayList(u8) = .{};
+    defer bufImgLayerZstd.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayerZstd, bufImgLayerZstd.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayerZstd, bufImgLayerZstd.writer(testing.allocator));
 
     // ImageLayerNonDistributable
-    var bufImgLayerNonDist = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgLayerNonDist.deinit();
+    var bufImgLayerNonDist: std.ArrayList(u8) = .{};
+    defer bufImgLayerNonDist.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributable, bufImgLayerNonDist.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributable, bufImgLayerNonDist.writer(testing.allocator));
 
     // ImageLayerNonDistributableGzip
-    var bufImgLayerNonDistGzip = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgLayerNonDistGzip.deinit();
+    var bufImgLayerNonDistGzip: std.ArrayList(u8) = .{};
+    defer bufImgLayerNonDistGzip.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributableGzip, bufImgLayerNonDistGzip.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributableGzip, bufImgLayerNonDistGzip.writer(testing.allocator));
 
     // ImageLayerNonDistributableZstd
-    var bufImgLayerNonDistZstd = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgLayerNonDistZstd.deinit();
+    var bufImgLayerNonDistZstd: std.ArrayList(u8) = .{};
+    defer bufImgLayerNonDistZstd.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributableZstd, bufImgLayerNonDistZstd.writer());
+    try imgtype.jsonStringify(&imgtype.ImageLayerNonDistributableZstd, bufImgLayerNonDistZstd.writer(testing.allocator));
 
     // ImageConfig
-    var bufImgConfig = std.ArrayList(u8).init(testing.allocator);
-    defer bufImgConfig.deinit();
+    var bufImgConfig: std.ArrayList(u8) = .{};
+    defer bufImgConfig.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ImageConfig, bufImgConfig.writer());
+    try imgtype.jsonStringify(&imgtype.ImageConfig, bufImgConfig.writer(testing.allocator));
 
     // ArtifactManifest
-    var bufArtManifest = std.ArrayList(u8).init(testing.allocator);
-    defer bufArtManifest.deinit();
+    var bufArtManifest: std.ArrayList(u8) = .{};
+    defer bufArtManifest.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.ArtifactManifest, bufArtManifest.writer());
+    try imgtype.jsonStringify(&imgtype.ArtifactManifest, bufArtManifest.writer(testing.allocator));
 
     // EmptyJSON
-    var bufEmptyJson = std.ArrayList(u8).init(testing.allocator);
-    defer bufEmptyJson.deinit();
+    var bufEmptyJson: std.ArrayList(u8) = .{};
+    defer bufEmptyJson.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.EmptyJSON, bufEmptyJson.writer());
+    try imgtype.jsonStringify(&imgtype.EmptyJSON, bufEmptyJson.writer(testing.allocator));
 
     // Other
-    var bufOther = std.ArrayList(u8).init(testing.allocator);
-    defer bufOther.deinit();
+    var bufOther: std.ArrayList(u8) = .{};
+    defer bufOther.deinit(testing.allocator);
 
-    try imgtype.jsonStringify(&imgtype.Other, bufOther.writer());
+    try imgtype.jsonStringify(&imgtype.Other, bufOther.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(bufDesc.items, "\"application/vnd.oci.descriptor\"");

--- a/tests/image/define_os.zig
+++ b/tests/image/define_os.zig
@@ -5,112 +5,112 @@ const testing = std.testing;
 
 test "image define OS jsonStringify" {
     // AIX
-    var osAIXBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osAIXBuf.deinit();
+    var osAIXBuf: std.ArrayList(u8) = .{};
+    defer osAIXBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.AIX, osAIXBuf.writer());
+    try osimage.jsonStringify(&osimage.AIX, osAIXBuf.writer(testing.allocator));
 
     // Android
-    var osAndroidBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osAndroidBuf.deinit();
+    var osAndroidBuf: std.ArrayList(u8) = .{};
+    defer osAndroidBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Android, osAndroidBuf.writer());
+    try osimage.jsonStringify(&osimage.Android, osAndroidBuf.writer(testing.allocator));
 
     // Darwin
-    var osDarwinBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osDarwinBuf.deinit();
+    var osDarwinBuf: std.ArrayList(u8) = .{};
+    defer osDarwinBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Darwin, osDarwinBuf.writer());
+    try osimage.jsonStringify(&osimage.Darwin, osDarwinBuf.writer(testing.allocator));
 
     // DragonFlyBSD
-    var osDragonflyBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osDragonflyBuf.deinit();
+    var osDragonflyBuf: std.ArrayList(u8) = .{};
+    defer osDragonflyBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.DragonFlyBSD, osDragonflyBuf.writer());
+    try osimage.jsonStringify(&osimage.DragonFlyBSD, osDragonflyBuf.writer(testing.allocator));
 
     // FreeBSD
-    var osFreeBSDBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osFreeBSDBuf.deinit();
+    var osFreeBSDBuf: std.ArrayList(u8) = .{};
+    defer osFreeBSDBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.FreeBSD, osFreeBSDBuf.writer());
+    try osimage.jsonStringify(&osimage.FreeBSD, osFreeBSDBuf.writer(testing.allocator));
 
     // Hurd
-    var osHurdBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osHurdBuf.deinit();
+    var osHurdBuf: std.ArrayList(u8) = .{};
+    defer osHurdBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Hurd, osHurdBuf.writer());
+    try osimage.jsonStringify(&osimage.Hurd, osHurdBuf.writer(testing.allocator));
 
     // Illumos
-    var osIllumosBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osIllumosBuf.deinit();
+    var osIllumosBuf: std.ArrayList(u8) = .{};
+    defer osIllumosBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Illumos, osIllumosBuf.writer());
+    try osimage.jsonStringify(&osimage.Illumos, osIllumosBuf.writer(testing.allocator));
 
     // IOS
-    var osIOSBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osIOSBuf.deinit();
+    var osIOSBuf: std.ArrayList(u8) = .{};
+    defer osIOSBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.IOS, osIOSBuf.writer());
+    try osimage.jsonStringify(&osimage.IOS, osIOSBuf.writer(testing.allocator));
 
     // Js
-    var osJsBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osJsBuf.deinit();
+    var osJsBuf: std.ArrayList(u8) = .{};
+    defer osJsBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Js, osJsBuf.writer());
+    try osimage.jsonStringify(&osimage.Js, osJsBuf.writer(testing.allocator));
 
     // Linux
-    var osLinuxBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osLinuxBuf.deinit();
+    var osLinuxBuf: std.ArrayList(u8) = .{};
+    defer osLinuxBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Linux, osLinuxBuf.writer());
+    try osimage.jsonStringify(&osimage.Linux, osLinuxBuf.writer(testing.allocator));
 
     // Nacl
-    var osNaclBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osNaclBuf.deinit();
+    var osNaclBuf: std.ArrayList(u8) = .{};
+    defer osNaclBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Nacl, osNaclBuf.writer());
+    try osimage.jsonStringify(&osimage.Nacl, osNaclBuf.writer(testing.allocator));
 
     // NetBSD
-    var osNetBSDBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osNetBSDBuf.deinit();
+    var osNetBSDBuf: std.ArrayList(u8) = .{};
+    defer osNetBSDBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.NetBSD, osNetBSDBuf.writer());
+    try osimage.jsonStringify(&osimage.NetBSD, osNetBSDBuf.writer(testing.allocator));
 
     // OpenBSD
-    var osOpenBSDBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osOpenBSDBuf.deinit();
+    var osOpenBSDBuf: std.ArrayList(u8) = .{};
+    defer osOpenBSDBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.OpenBSD, osOpenBSDBuf.writer());
+    try osimage.jsonStringify(&osimage.OpenBSD, osOpenBSDBuf.writer(testing.allocator));
 
     // Plan9
-    var osPlan9Buf = std.ArrayList(u8).init(testing.allocator);
-    defer osPlan9Buf.deinit();
+    var osPlan9Buf: std.ArrayList(u8) = .{};
+    defer osPlan9Buf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Plan9, osPlan9Buf.writer());
+    try osimage.jsonStringify(&osimage.Plan9, osPlan9Buf.writer(testing.allocator));
 
     // Solaris
-    var osSolarisBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osSolarisBuf.deinit();
+    var osSolarisBuf: std.ArrayList(u8) = .{};
+    defer osSolarisBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Solaris, osSolarisBuf.writer());
+    try osimage.jsonStringify(&osimage.Solaris, osSolarisBuf.writer(testing.allocator));
 
     // Windows
-    var osWindowsBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osWindowsBuf.deinit();
+    var osWindowsBuf: std.ArrayList(u8) = .{};
+    defer osWindowsBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Windows, osWindowsBuf.writer());
+    try osimage.jsonStringify(&osimage.Windows, osWindowsBuf.writer(testing.allocator));
 
     // ZOS
-    var osZOSBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osZOSBuf.deinit();
+    var osZOSBuf: std.ArrayList(u8) = .{};
+    defer osZOSBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.ZOS, osZOSBuf.writer());
+    try osimage.jsonStringify(&osimage.ZOS, osZOSBuf.writer(testing.allocator));
 
     // Other
-    var osOtherBuf = std.ArrayList(u8).init(testing.allocator);
-    defer osOtherBuf.deinit();
+    var osOtherBuf: std.ArrayList(u8) = .{};
+    defer osOtherBuf.deinit(testing.allocator);
 
-    try osimage.jsonStringify(&osimage.Other, osOtherBuf.writer());
+    try osimage.jsonStringify(&osimage.Other, osOtherBuf.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(osAIXBuf.items, "\"aix\"");

--- a/tests/runtime/io_priority.zig
+++ b/tests/runtime/io_priority.zig
@@ -54,22 +54,22 @@ test "runtime LinuxIOPriorityType jsonParse" {
 
 test "runtime LinuxSchedulerPolicy jsonStringify" {
     // IoprioClassRt
-    var rt = std.ArrayList(u8).init(testing.allocator);
-    defer rt.deinit();
+    var rt: std.ArrayList(u8) = .{};
+    defer rt.deinit(testing.allocator);
 
-    try iopriority.jsonStringify(&iopriority.IoprioClassRt, rt.writer());
+    try iopriority.jsonStringify(&iopriority.IoprioClassRt, rt.writer(testing.allocator));
 
     // IoprioClassBe
-    var be = std.ArrayList(u8).init(testing.allocator);
-    defer be.deinit();
+    var be: std.ArrayList(u8) = .{};
+    defer be.deinit(testing.allocator);
 
-    try iopriority.jsonStringify(&iopriority.IoprioClassBe, be.writer());
+    try iopriority.jsonStringify(&iopriority.IoprioClassBe, be.writer(testing.allocator));
 
     // IoprioClassIdle
-    var idle = std.ArrayList(u8).init(testing.allocator);
-    defer idle.deinit();
+    var idle: std.ArrayList(u8) = .{};
+    defer idle.deinit(testing.allocator);
 
-    try iopriority.jsonStringify(&iopriority.IoprioClassIdle, idle.writer());
+    try iopriority.jsonStringify(&iopriority.IoprioClassIdle, idle.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(rt.items, "\"IOPRIO_CLASS_RT\"");

--- a/tests/runtime/scheduler_flag.zig
+++ b/tests/runtime/scheduler_flag.zig
@@ -114,46 +114,46 @@ test "runtime LinuxSchedulerFlag jsonParse" {
 
 test "runtime LinuxSchedulerFlag jsonStringify" {
     // SchedResetOnFork
-    var resetOnFork = std.ArrayList(u8).init(testing.allocator);
-    defer resetOnFork.deinit();
+    var resetOnFork: std.ArrayList(u8) = .{};
+    defer resetOnFork.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedResetOnFork, resetOnFork.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedResetOnFork, resetOnFork.writer(testing.allocator));
 
     // SchedFlagReclaim
-    var reclaim = std.ArrayList(u8).init(testing.allocator);
-    defer reclaim.deinit();
+    var reclaim: std.ArrayList(u8) = .{};
+    defer reclaim.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagReclaim, reclaim.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagReclaim, reclaim.writer(testing.allocator));
 
     // SchedFlagDLOverrun
-    var overrun = std.ArrayList(u8).init(testing.allocator);
-    defer overrun.deinit();
+    var overrun: std.ArrayList(u8) = .{};
+    defer overrun.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagDLOverrun, overrun.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagDLOverrun, overrun.writer(testing.allocator));
 
     // SchedFlagKeepPolicy
-    var keepPolicy = std.ArrayList(u8).init(testing.allocator);
-    defer keepPolicy.deinit();
+    var keepPolicy: std.ArrayList(u8) = .{};
+    defer keepPolicy.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagKeepPolicy, keepPolicy.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagKeepPolicy, keepPolicy.writer(testing.allocator));
 
     // SchedFlagKeepParams
-    var keepParam = std.ArrayList(u8).init(testing.allocator);
-    defer keepParam.deinit();
+    var keepParam: std.ArrayList(u8) = .{};
+    defer keepParam.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagKeepParams, keepParam.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagKeepParams, keepParam.writer(testing.allocator));
 
     // SchedFlagUtilClampMin
-    var clammin = std.ArrayList(u8).init(testing.allocator);
-    defer clammin.deinit();
+    var clammin: std.ArrayList(u8) = .{};
+    defer clammin.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagUtilClampMin, clammin.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagUtilClampMin, clammin.writer(testing.allocator));
 
     // SchedFlagUtilClampMax
-    var clammax = std.ArrayList(u8).init(testing.allocator);
-    defer clammax.deinit();
+    var clammax: std.ArrayList(u8) = .{};
+    defer clammax.deinit(testing.allocator);
 
-    try schedFlag.jsonStringify(&schedFlag.SchedFlagUtilClampMax, clammax.writer());
+    try schedFlag.jsonStringify(&schedFlag.SchedFlagUtilClampMax, clammax.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(resetOnFork.items, "\"SCHED_FLAG_RESET_ON_FORK\"");

--- a/tests/runtime/scheduler_policy.zig
+++ b/tests/runtime/scheduler_policy.zig
@@ -114,46 +114,46 @@ test "runtime LinuxSchedulerPolicy jsonParse" {
 
 test "runtime LinuxSchedulerPolicy jsonStringify" {
     // SchedOther
-    var other = std.ArrayList(u8).init(testing.allocator);
-    defer other.deinit();
+    var other: std.ArrayList(u8) = .{};
+    defer other.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedOther, other.writer());
+    try policy.jsonStringify(&policy.SchedOther, other.writer(testing.allocator));
 
     // SchedFifo
-    var fifo = std.ArrayList(u8).init(testing.allocator);
-    defer fifo.deinit();
+    var fifo: std.ArrayList(u8) = .{};
+    defer fifo.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedFifo, fifo.writer());
+    try policy.jsonStringify(&policy.SchedFifo, fifo.writer(testing.allocator));
 
     // SchedRr
-    var rr = std.ArrayList(u8).init(testing.allocator);
-    defer rr.deinit();
+    var rr: std.ArrayList(u8) = .{};
+    defer rr.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedRr, rr.writer());
+    try policy.jsonStringify(&policy.SchedRr, rr.writer(testing.allocator));
 
     // SchedBatch
-    var batch = std.ArrayList(u8).init(testing.allocator);
-    defer batch.deinit();
+    var batch: std.ArrayList(u8) = .{};
+    defer batch.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedBatch, batch.writer());
+    try policy.jsonStringify(&policy.SchedBatch, batch.writer(testing.allocator));
 
     // SchedIso
-    var iso = std.ArrayList(u8).init(testing.allocator);
-    defer iso.deinit();
+    var iso: std.ArrayList(u8) = .{};
+    defer iso.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedIso, iso.writer());
+    try policy.jsonStringify(&policy.SchedIso, iso.writer(testing.allocator));
 
     // SchedIdle
-    var idle = std.ArrayList(u8).init(testing.allocator);
-    defer idle.deinit();
+    var idle: std.ArrayList(u8) = .{};
+    defer idle.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedIdle, idle.writer());
+    try policy.jsonStringify(&policy.SchedIdle, idle.writer(testing.allocator));
 
     // SchedDeadline
-    var deadline = std.ArrayList(u8).init(testing.allocator);
-    defer deadline.deinit();
+    var deadline: std.ArrayList(u8) = .{};
+    defer deadline.deinit(testing.allocator);
 
-    try policy.jsonStringify(&policy.SchedDeadline, deadline.writer());
+    try policy.jsonStringify(&policy.SchedDeadline, deadline.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(other.items, "\"SCHED_OTHER\"");

--- a/tests/runtime/zos.zig
+++ b/tests/runtime/zos.zig
@@ -53,28 +53,28 @@ test "runtime ZosNamespaceType jsonParse" {
 
 test "runtime ZosNamespaceType jsonStringify" {
     // Mount
-    var nsMount = std.ArrayList(u8).init(testing.allocator);
-    defer nsMount.deinit();
+    var nsMount: std.ArrayList(u8) = .{};
+    defer nsMount.deinit(testing.allocator);
 
-    try zosnsType.jsonStringify(&zosnsType.Mount, nsMount.writer());
+    try zosnsType.jsonStringify(&zosnsType.Mount, nsMount.writer(testing.allocator));
 
     // Pid
-    var nsPid = std.ArrayList(u8).init(testing.allocator);
-    defer nsPid.deinit();
+    var nsPid: std.ArrayList(u8) = .{};
+    defer nsPid.deinit(testing.allocator);
 
-    try zosnsType.jsonStringify(&zosnsType.Pid, nsPid.writer());
+    try zosnsType.jsonStringify(&zosnsType.Pid, nsPid.writer(testing.allocator));
 
     // Ipc
-    var nsIpc = std.ArrayList(u8).init(testing.allocator);
-    defer nsIpc.deinit();
+    var nsIpc: std.ArrayList(u8) = .{};
+    defer nsIpc.deinit(testing.allocator);
 
-    try zosnsType.jsonStringify(&zosnsType.Ipc, nsIpc.writer());
+    try zosnsType.jsonStringify(&zosnsType.Ipc, nsIpc.writer(testing.allocator));
 
     // Uts
-    var nsUts = std.ArrayList(u8).init(testing.allocator);
-    defer nsUts.deinit();
+    var nsUts: std.ArrayList(u8) = .{};
+    defer nsUts.deinit(testing.allocator);
 
-    try zosnsType.jsonStringify(&zosnsType.Uts, nsUts.writer());
+    try zosnsType.jsonStringify(&zosnsType.Uts, nsUts.writer(testing.allocator));
 
     // test
     try testing.expectEqualStrings(nsMount.items, "\"mount\"");


### PR DESCRIPTION
- utils.zig: std.json.stringifyAlloc to std.json.Stringify.valueAlloc
- runtime/define.zig: std.ArrayList(T).init(alloc) to std.ArrayListUnmanaged(T) with explicit allocator on append/toOwnedSlice
- build.zig: remove addStaticLibrary (removed in 0.15), use createModule for examples and tests
- examples: std.io.getStdOut() to std.fs.File.stdout().deprecatedWriter()
- tests: ArrayList(u8).init to ArrayListUnmanaged pattern, .writer(allocator), .deinit(allocator)